### PR TITLE
Small bug-fix for checkbox-fold + Small css change

### DIFF
--- a/admin/admin-interface.php
+++ b/admin/admin-interface.php
@@ -1,4 +1,4 @@
-17<?php
+<?php
 /*-----------------------------------------------------------------------------------*/
 /* Title: Aquagraphite Options Framework
 /* Author: Syamil MJ
@@ -906,6 +906,7 @@ public static function optionsframework_machine($options) {
 		 {
 		 	$class = ''; if(isset( $value['class'] )) { $class = $value['class']; }
 			
+        $fold='';
 			  //hide items in checkbox-group
 			  if (array_key_exists("fold",$value)) {
 				if ($data[$value['fold']]) {

--- a/admin/admin-style.css
+++ b/admin/admin-style.css
@@ -182,7 +182,7 @@ border-radius: 2px;
 }
 #of_container #content .section .explain {
 	float: left;
-	width: 225px;
+/*  width: 225px; */
 	padding: 0 10px 0 0;
 	font-size: 11px;
 	color: #999999;


### PR DESCRIPTION
- Forgot to reset a variable between items, so if you have a fold-group, everything after it laso gets folded.
- The info line after checkboxes (for example) was limited to 225px, commented that out
