### PR TITLE
Theme Version in Options Header

### DIFF
--- a/admin/assets/css/admin-style.css
+++ b/admin/assets/css/admin-style.css
@@ -44,7 +44,12 @@
  }
 
 #of_container #header .logo h2 {
+	display:inline-block;
 	font-style:normal;
+	padding-right:5px;
+}
+#of_container #header .logo span {
+	color:#888888;
 }
 #of_container #header .icon-option {
 	float: right;

--- a/admin/front-end/options.php
+++ b/admin/front-end/options.php
@@ -22,7 +22,7 @@
 		
 			<div class="logo">
 				<h2><?php echo THEMENAME; ?></h2>
-				<span><?php echo THEMEVERSION; ?></h2>
+				<span><?php echo ('v'. THEMEVERSION); ?></span>
 			</div>
 		
 			<div id="js-warning">Warning- This options panel will not work properly without javascript!</div>

--- a/admin/front-end/options.php
+++ b/admin/front-end/options.php
@@ -22,6 +22,7 @@
 		
 			<div class="logo">
 				<h2><?php echo THEMENAME; ?></h2>
+				<span><?php echo THEMEVERSION; ?></h2>
 			</div>
 		
 			<div id="js-warning">Warning- This options panel will not work properly without javascript!</div>


### PR DESCRIPTION
I'm having trouble figuring out how GitHub works, haha, but I'd like to add the theme version to the header of the options page.

In admin/front-end/options.php after `<h2><?php echo THEMENAME; ?></h2>` add `<span><?php echo ('v' . THEMEVERSION); ?></span>`. 

In admin/assets/css/admin-style.css for `#of_container #header .logo h2` add the lines `display:inline-block;padding-right:5px;` and make a new rule for `#of_container #header .logo span` of `color:#888888;`.
