### PR TITLE
Keep Site URL Out of Database

### DIFF
--- a/admin/classes/class.options_machine.php
+++ b/admin/classes/class.options_machine.php
@@ -38,7 +38,7 @@ class Options_Machine {
 	 */
 	public static function optionsframework_machine($options) {
 	
-	    $data = get_option(OPTIONS);
+	    $data = of_get_options();
 		
 		$defaults = array();   
 	    $counter = 0;
@@ -511,7 +511,7 @@ class Options_Machine {
 	 */
 	public static function optionsframework_uploader_function($id,$std,$mod){
 	
-	    $data =get_option(OPTIONS);
+	    $data = of_get_options();
 		
 		$uploader = '';
 	    $upload = $data[$id];
@@ -554,7 +554,7 @@ class Options_Machine {
 	 */
 	public static function optionsframework_media_uploader_function($id,$std,$int,$mod){
 	
-	    $data =get_option(OPTIONS);
+	    $data = of_get_options();
 		
 		$uploader = '';
 	    $upload = $data[$id];
@@ -596,7 +596,7 @@ class Options_Machine {
 	 */
 	public static function optionsframework_slider_function($id,$std,$oldorder,$order,$int){
 	
-	    $data = get_option(OPTIONS);
+	    $data = of_get_options();
 		
 		$slider = '';
 		$slide = array();

--- a/admin/functions/functions.admin.php
+++ b/admin/functions/functions.admin.php
@@ -73,7 +73,7 @@ function of_get_header_classes_array()
 }
 
 /**
- * Get options from the database.
+ * Get options from the database and process them with the load filter hook.
  *
  * @author Jonah Dahlquist
  * @since 1.4.0
@@ -82,12 +82,13 @@ function of_get_header_classes_array()
 function of_get_options()
 {
 	$data = get_option(OPTIONS);
+	$data = apply_filters('of_after_options_load', $data);
 
 	return $data;
 }
 
 /**
- * Save options to the database.
+ * Save options to the database after processing them
  *
  * @param $data Options array to save
  * @author Jonah Dahlquist
@@ -97,6 +98,7 @@ function of_get_options()
  */
 function of_save_options($data)
 {
+	$data = apply_filters('of_before_options_save', $data);
 	update_option(OPTIONS, $data);
 }
 

--- a/admin/functions/functions.admin.php
+++ b/admin/functions/functions.admin.php
@@ -79,9 +79,9 @@ function of_get_header_classes_array()
  * @since 1.4.0
  * @return array
  */
-function of_get_options()
+function of_get_options($key=OPTIONS)
 {
-	$data = get_option(OPTIONS);
+	$data = get_option($key);
 	$data = apply_filters('of_after_options_load', $data);
 
 	return $data;
@@ -96,10 +96,10 @@ function of_get_options()
  * @uses update_option()
  * @return void
  */
-function of_save_options($data)
+function of_save_options($data, $key=OPTIONS)
 {
 	$data = apply_filters('of_before_options_save', $data);
-	update_option(OPTIONS, $data);
+	update_option($key, $data);
 }
 
 

--- a/admin/functions/functions.admin.php
+++ b/admin/functions/functions.admin.php
@@ -6,6 +6,7 @@
  * @subpackage  SMOF
  * @since       1.4.0
  * @author      Syamil MJ
+ * @author      Jonah Dahlquist
  */
  
 
@@ -26,9 +27,9 @@ function of_option_setup()
 	global $of_options, $options_machine;
 	$options_machine = new Options_Machine($of_options);
 		
-	if (!get_option(OPTIONS))
+	if (!of_get_options())
 	{
-		update_option(OPTIONS,$options_machine->Defaults);
+		of_save_options($options_machine->Defaults);
 	}
 }
 
@@ -71,10 +72,38 @@ function of_get_header_classes_array()
 	return $hooks;
 }
 
+/**
+ * Get options from the database.
+ *
+ * @author Jonah Dahlquist
+ * @since 1.4.0
+ * @return array
+ */
+function of_get_options()
+{
+	$data = get_option(OPTIONS);
+
+	return $data;
+}
+
+/**
+ * Save options to the database.
+ *
+ * @param $data Options array to save
+ * @author Jonah Dahlquist
+ * @since 1.4.0
+ * @uses update_option()
+ * @return void
+ */
+function of_save_options($data)
+{
+	update_option(OPTIONS, $data);
+}
+
 
 /**
  * For use in themes
  *
  * @since forever
  */
-$data = get_option(OPTIONS);
+$data = of_get_options();

--- a/admin/functions/functions.filters.php
+++ b/admin/functions/functions.filters.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * SMOF Option filters
+ *
+ * @package     WordPress
+ * @subpackage  SMOF
+ * @since       1.4.0
+ * @author      Jonah Dahlquist
+ */

--- a/admin/functions/functions.filters.php
+++ b/admin/functions/functions.filters.php
@@ -8,3 +8,64 @@
  * @since       1.4.0
  * @author      Jonah Dahlquist
  */
+
+/**
+ * Filter URLs from uploaded media fields and replaces them with keywords.
+ * This is to keep from storing the site URL in the database to make
+ * migrations easier.
+ * 
+ * @since 1.4.0
+ * @param $data Options array
+ * @return array
+ */
+function of_filter_save_media_upload($data) {
+
+    foreach ($data as $key => $value) {
+        if (is_string($value)) {
+            $data[$key] = str_replace(
+                array(
+                    site_url('', 'http'),
+                    site_url('', 'https'),
+                ),
+                array(
+                    '[site_url]',
+                    '[site_url_secure]',
+                ),
+                $value
+            );
+        }
+    }
+
+    return $data;
+}
+add_filter('of_options_before_save', 'of_filter_save_media_upload');
+
+/**
+ * Filter URLs from uploaded media fields and replaces the site URL keywords
+ * with the actual site URL.
+ * 
+ * @since 1.4.0
+ * @param $data Options array
+ * @return array
+ */
+function of_filter_load_media_upload($data) {
+
+    foreach ($data as $key => $value) {
+        if (is_string($value)) {
+            $data[$key] = str_replace(
+                array(
+                    '[site_url]', 
+                    '[site_url_secure]',
+                ),
+                array(
+                    site_url('', 'http'),
+                    site_url('', 'https'),
+                ),
+                $value
+            );
+        }
+    }
+
+    return $data;
+}
+add_filter('of_options_after_load', 'of_filter_load_media_upload');

--- a/admin/functions/functions.interface.php
+++ b/admin/functions/functions.interface.php
@@ -202,7 +202,7 @@ function of_ajax_callback()
 		$backup = $all;
 		$backup['backup_log'] = date('r');
 		
-		of_save_options($backup ) ;
+		of_save_options($backup, BACKUPS) ;
 			
 		die('1'); 
 	}

--- a/admin/functions/functions.interface.php
+++ b/admin/functions/functions.interface.php
@@ -14,7 +14,6 @@
  *
  * @uses wp_verify_nonce()
  * @uses header()
- * @uses update_option()
  *
  * @since 1.0.0
  */
@@ -56,7 +55,7 @@ function optionsframework_options_page(){
 	global $options_machine;
 	/*
 	//for debugging
-	$data = get_option(OPTIONS);
+	$data = of_get_options();
 	print_r($data);
 	*/	
 	
@@ -143,7 +142,6 @@ function of_admin_head() { ?>
  * Ajax Save Options
  *
  * @uses get_option()
- * @uses update_option()
  *
  * @since 1.0.0
  */
@@ -156,7 +154,7 @@ function of_ajax_callback()
 	if (! wp_verify_nonce($nonce, 'of_ajax_nonce') ) die('-1'); 
 			
 	//get options array from db
-	$all = get_option(OPTIONS);
+	$all = of_get_options();
 	
 	$save_type = $_POST['type'];
 	
@@ -181,7 +179,7 @@ function of_ajax_callback()
 			
 			$upload_image[$clickedID] = $uploaded_file['url'];
 			
-			update_option(OPTIONS, $upload_image ) ;
+			of_save_options($upload_image);
 		
 				
 		 if(!empty($uploaded_file['error'])) {echo 'Upload Error: ' . $uploaded_file['error']; }	
@@ -195,7 +193,7 @@ function of_ajax_callback()
 			
 			$delete_image = $all; //preserve rest of data
 			$delete_image[$id] = ''; //update array key with empty value	 
-			update_option(OPTIONS, $delete_image ) ;
+			of_save_options($delete_image ) ;
 	
 	}
 	elseif($save_type == 'backup_options')
@@ -204,7 +202,7 @@ function of_ajax_callback()
 		$backup = $all;
 		$backup['backup_log'] = date('r');
 		
-		update_option(BACKUPS, $backup ) ;
+		of_save_options($backup ) ;
 			
 		die('1'); 
 	}
@@ -213,7 +211,7 @@ function of_ajax_callback()
 			
 		$data = get_option(BACKUPS);
 		
-		update_option(OPTIONS, $data);
+		of_save_options($data);
 		
 		die('1'); 
 	}
@@ -221,7 +219,7 @@ function of_ajax_callback()
 			
 		$data = $_POST['data'];
 		$data = unserialize(base64_decode($data)); //100% safe - ignore theme check nag
-		update_option(OPTIONS, $data);
+		of_save_options($data);
 		
 		die('1'); 
 	}
@@ -230,13 +228,13 @@ function of_ajax_callback()
 		wp_parse_str(stripslashes($_POST['data']), $data);
 		unset($data['security']);
 		unset($data['of_save']);
-		update_option(OPTIONS, $data);
+		of_save_options($data);
 		
 		die('1');
 	}
 	elseif ($save_type == 'reset')
 	{
-		update_option(OPTIONS,$options_machine->Defaults);
+		of_save_options($options_machine->Defaults);
 		
         die('1'); //options reset
 	}

--- a/admin/functions/functions.load.php
+++ b/admin/functions/functions.load.php
@@ -12,3 +12,4 @@ require_once( ADMIN_PATH . 'functions/functions.interface.php' );
 require_once( ADMIN_PATH . 'functions/functions.options.php' );
 require_once( ADMIN_PATH . 'functions/functions.admin.php' );
 require_once( ADMIN_PATH . 'functions/functions.mediauploader.php' );
+require_once( ADMIN_PATH . 'functions/functions.filters.php' );

--- a/admin/functions/functions.load.php
+++ b/admin/functions/functions.load.php
@@ -8,8 +8,8 @@
  * @author      Syamil MJ
  */
 require_once( ADMIN_PATH . 'functions/functions.php' );
+require_once( ADMIN_PATH . 'functions/functions.filters.php' );
 require_once( ADMIN_PATH . 'functions/functions.interface.php' );
 require_once( ADMIN_PATH . 'functions/functions.options.php' );
 require_once( ADMIN_PATH . 'functions/functions.admin.php' );
 require_once( ADMIN_PATH . 'functions/functions.mediauploader.php' );
-require_once( ADMIN_PATH . 'functions/functions.filters.php' );

--- a/admin/functions/functions.options.php
+++ b/admin/functions/functions.options.php
@@ -114,14 +114,16 @@ $of_options[] = array( "name" => "Hello there!",
 					"type" => "info");
 					
 $of_options[] = array( "name" => "Media Uploader",
-					"desc" => "Upload images using the native media uploader, or define the URL directly",
+					"desc" => "Upload images using the native media uploader, or define the URL directly.  The framework will make sure the actual site URL is not stored in the setting, to make migrating WordPress installations easier.",
 					"id" => "media_upload",
+					// Use the shortcodes [site_url] or [site_url_secure] for setting default URLs
 					"std" => "",
 					"type" => "media");
 					
 $of_options[] = array( "name" => "Media Uploader Min",
 					"desc" => "Upload images using native media uploader. This is a min version, meaning it has no url to copy paste. Perfect for logo.",
 					"id" => "media_upload_2",
+					// Use the shortcodes [site_url] or [site_url_secure] for setting default URLs
 					"std" => "",
 					"mod" => "min",
 					"type" => "media");


### PR DESCRIPTION
Often, migrating a WordPress site can be made very difficult for a developer because the site URL is in the database in so many different places.  This change adds the ability to filter data on save and load, and adds filters for stripping out the site URL from strings and replacing it with a pseudo-shortcode on save, and vice versa on load.
