### PR TITLE
Update functions.interface.php

### DIFF
--- a/admin/functions/functions.interface.php
+++ b/admin/functions/functions.interface.php
@@ -89,7 +89,7 @@ function of_style_only(){
  */
 function of_load_only() 
 {
-	add_action('admin_head', 'of_admin_head');
+	add_action('admin_head', 'smof_admin_head');
 	
 	wp_enqueue_script('jquery-ui-core');
 	wp_enqueue_script('jquery-ui-sortable');
@@ -107,7 +107,7 @@ function of_load_only()
  *
  * @since 1.0.0
  */
-function of_admin_head() { ?>
+function smof_admin_head() { ?>
 		
 	<script type="text/javascript" language="javascript">
 


### PR DESCRIPTION
Avoids conflict with Options Framework Plugin (http://wordpress.org/extend/plugins/options-framework/). Changing the function name from 'of_admin_head' to 'smof_admin_head' gives the flexibility to use both Options Framework Plugin and SMOF at a time.
