### PR TITLE
Removing closing ?> PHP tags

### DIFF
--- a/admin/functions/functions.options.php
+++ b/admin/functions/functions.options.php
@@ -561,4 +561,3 @@ $of_options[] = array( 	"name" 		=> "Transfer Theme Options Data",
 				
 	}//End function: of_options()
 }//End chack if function exists: of_options()
-?>

--- a/template-debug.php
+++ b/template-debug.php
@@ -3,12 +3,9 @@
 Template Name: Debug
 */
 get_header();
-?>
-		<pre>
-		<?php 
-		$smof_data_r = print_r($smof_data, true); 
-		$smof_data_r_sans = htmlspecialchars($smof_data_r, ENT_QUOTES); 
-		echo $smof_data_r_sans; ?>
-		</pre>
-	
-<?php get_footer(); ?>
+echo '<pre>';
+$smof_data_r = print_r($smof_data, true);
+$smof_data_r_sans = htmlspecialchars($smof_data_r, ENT_QUOTES);
+echo $smof_data_r_sans;
+echo '</pre>';
+get_footer();


### PR DESCRIPTION
Closing PHP tags have the tendency to cause errors like `Warning: Cannot modify header information - headers already sent by .............` if there is a space or blank line after them.
This small fix should take care of these errors mentioned near the end of this comment: https://github.com/sy4mil/Options-Framework/pull/232#issuecomment-18791239
