### PR TITLE
Allow &tab= to be used to define active tab in the URL

### DIFF
--- a/admin/assets/js/smof.js
+++ b/admin/assets/js/smof.js
@@ -26,6 +26,18 @@ jQuery(document).ready(function($){
 	//Tabify Options			
 	$('.group').hide();
 	
+	// Get the URL parameter for tab
+	function getURLParameter(name) {
+	    return decodeURI(
+	        (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,''])[1]
+	    );
+	}
+	
+	// If the $_GET param of tab is set, use that for the tab that should be open
+	if (getURLParameter('tab') != "") {
+		$.cookie('of_current_opt', '#'+getURLParameter('tab'), { expires: 7, path: '/' });
+	}
+
 	// Display last current tab	
 	if ($.cookie("of_current_opt") === null) {
 		$('.group:first').fadeIn('fast');	

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,7 @@ Website: http://aquagraphite.com
 ### Changelog
 
 **v1.5.2**
+* Added the ability to use &tab= in the URL to define the active tab
 * Extra checks for DB saving to reduce server overhead
 * Added default colors to color picker instead of clear option
 * Fixed speed issues, 250% reduction in load time with new class


### PR DESCRIPTION
Small but useful item to allow &tab= to define the open tab instead of just a cookie. Feel free to merge this right in. I've updated the change log for this addition.
