### PR TITLE
Added Google Font Preview Functionality / Fixed Google Font Selects

### DIFF
--- a/admin/assets/js/smof.js
+++ b/admin/assets/js/smof.js
@@ -614,19 +614,19 @@ jQuery(document).ready(function($){
 			//Check if selected is not equal with "Select a font" and execute the script.
 			if ( _selected !== 'none' && _selected !== 'Select a font' ) {
 				var selected = _selected.split(':'),
-					fontFamily = selected[0].replace('+', ' '),
-					_italic = _selected.match(/italic/i),
+					fontFamily = selected[0].replace('+', ' '), //grab the font family
+					_italic = _selected.match(/italic/i), // do we have italic?
 					fontWeight,
 					fontStyle;
 					
-				console.log(_selected);
-					
+				// If we have italic, use that. Else use normal
 				if(_italic){
 					fontStyle = _italic[0];
 				} else {
 					fontStyle = 'normal';
 				}
 				
+				// if we have a font weight, use that. Else use 300 (default)
 				if(selected[1] && _italic){
 					fontWeight = selected[1].slice(0, -6);
 				} else if(selected[1] && !_italic) {
@@ -643,7 +643,6 @@ jQuery(document).ready(function($){
 				
 				//add reference to google font family
 				$('head').append('<link href="http://fonts.googleapis.com/css?family='+ the_font +'" rel="stylesheet" type="text/css" class="'+ _linkclass +'">');
-				console.log('<link href="http://fonts.googleapis.com/css?family='+ the_font +'" rel="stylesheet" type="text/css" class="'+ _linkclass +'">');
 				
 				//show in the preview box the font
 				$('.'+ _previewer ).css({

--- a/admin/assets/js/smof.js
+++ b/admin/assets/js/smof.js
@@ -609,11 +609,31 @@ jQuery(document).ready(function($){
 		var _previewer = mainID +'_ggf_previewer';
 		
 		if( _selected ){ //if var exists and isset
-
 			$('.'+ _previewer ).fadeIn();
 			
 			//Check if selected is not equal with "Select a font" and execute the script.
 			if ( _selected !== 'none' && _selected !== 'Select a font' ) {
+				var selected = _selected.split(':'),
+					fontFamily = selected[0].replace('+', ' '),
+					_italic = _selected.match(/italic/i),
+					fontWeight,
+					fontStyle;
+					
+				console.log(_selected);
+					
+				if(_italic){
+					fontStyle = _italic[0];
+				} else {
+					fontStyle = 'normal';
+				}
+				
+				if(selected[1] && _italic){
+					fontWeight = selected[1].slice(0, -6);
+				} else if(selected[1] && !_italic) {
+					fontWeight = selected[1];
+				} else {
+					fontWeight = '300';
+				}
 				
 				//remove other elements crested in <head>
 				$( '.'+ _linkclass ).remove();
@@ -623,9 +643,14 @@ jQuery(document).ready(function($){
 				
 				//add reference to google font family
 				$('head').append('<link href="http://fonts.googleapis.com/css?family='+ the_font +'" rel="stylesheet" type="text/css" class="'+ _linkclass +'">');
+				console.log('<link href="http://fonts.googleapis.com/css?family='+ the_font +'" rel="stylesheet" type="text/css" class="'+ _linkclass +'">');
 				
 				//show in the preview box the font
-				$('.'+ _previewer ).css('font-family', _selected +', sans-serif' );
+				$('.'+ _previewer ).css({
+					'font-family': fontFamily +', sans-serif', 
+					'font-weight': fontWeight,
+					'font-style': fontStyle 
+				});
 				
 			}else{
 				

--- a/admin/classes/class.options_machine.php
+++ b/admin/classes/class.options_machine.php
@@ -171,8 +171,18 @@ class Options_Machine {
 				case 'select':
 					$mini ='';
 					if(!isset($value['mod'])) $value['mod'] = '';
+					$folds = '';
+					if (array_key_exists("folds",$value)) $folds="fld ";
+					$fold='';
+					if (array_key_exists("fold",$value)) {
+						if (isset($value['fold']) && $value['fold']) {
+							$fold="f_".$value['fold']." temphide ";
+						} else {
+							$fold="f_".$value['fold']." temphide ";
+						}
+					}
 					if($value['mod'] == 'mini') { $mini = 'mini';}
-					$output .= '<div class="select_wrapper ' . $mini . '">';
+					$output .= '<div class="'.$folds . $fold.'select_wrapper ' . $mini . '">';
 					$output .= '<select class="select of-input" name="'.$value['id'].'" id="'. $value['id'] .'">';
 
 					foreach ($value['options'] as $select_ID => $option) {
@@ -574,7 +584,12 @@ class Options_Machine {
 					$output .= '<div class="select_wrapper">';
 					$output .= '<select class="select of-input google_font_select" name="'.$value['id'].'" id="'. $value['id'] .'">';
 					foreach ($value['options'] as $select_key => $option) {
-						$output .= '<option value="'.$select_key.'" ' . selected((isset($smof_data[$value['id']]))? $smof_data[$value['id']] : "", $option, false) . ' />'.$option.'</option>';
+						if($select_key == $smof_data[$value['id']]){
+							$selected = 'selected="selected"';
+						} else {
+							$selected = '';
+						}
+						$output .= '<option value="'.$select_key.'" ' . $selected . ' />'.$option.'</option>';
 					} 
 					$output .= '</select></div>';
 					


### PR DESCRIPTION
Google fonts can now use weight and italic for each font. To use them define them like so:

```
     "options" => array(
            "none" => "Select a font",
            "Lato:900" => "Lato", // Ultra bold
            "Lobster+Two:700italic" => "Lobster Two Bold Italic", // Bold Italic
            "Playfair+Display:900italic" => "Playfair Display Black Italic" // Ultra Bold Italic
        )
```

Also fixed an issue with google fonts that if you had more than one google font listed on the same tab, it would not select the correct value for the first google font or show the preview. 
