### PR TITLE
Convert the quotes to the HTML entity

### DIFF
--- a/admin/classes/class.options_machine.php
+++ b/admin/classes/class.options_machine.php
@@ -137,7 +137,7 @@ class Options_Machine {
 				//text input
 				case 'text':
 					$t_value = '';
-					$t_value = stripslashes($smof_data[$value['id']]);
+					$t_value = htmlentities($smof_data[$value['id']], ENT_QUOTES);
 					
 					$mini ='';
 					if(!isset($value['mod'])) $value['mod'] = '';


### PR DESCRIPTION
Use of double quotes in a text field will cause the string to stops at double-quote. For example, if we using a shortcode like [contact-form-7 id="1914" title="Contact form 1"] will cause the string to stops at id=:  [contact-form-7 id= Note that the issue can be seen after navigating to another theme option menu, refreshing the page then returning to the initial text field filled (empty the cache generated by ajax call).
